### PR TITLE
add Florence/ServiceSingleEntryPoint cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,8 @@ Naming/FileName:
     - lib/rubocop-florence.rb
 Rails:
   Enabled: false
+RSpec:
+  Language:
+    Expectations:
+      - expect_no_offenses
+      - expect_offense

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## [Unreleased]
+- Add cop: Florence/ServiceSingleEntryPoint
 
 ## [0.2.0] - 2022-09-13
 - Bump rubocop from 1.31 to 1.36

--- a/config/default.yml
+++ b/config/default.yml
@@ -5,6 +5,11 @@ inherit_mode:
 
 AllCops:
   NewCops: enable
+Florence/ServiceSingleEntryPoint:
+  Description: 'Service objects should only have one entry point.'
+  Enabled: true
+  VersionAdded: '0.3.0'
+  Include: ['app/**/services/**/*.rb']
 Lint/MissingSuper:
   Enabled: false
 Metrics/BlockLength:

--- a/lib/rubocop/cop/florence/service_single_entry_point.rb
+++ b/lib/rubocop/cop/florence/service_single_entry_point.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Florence
+      class ServiceSingleEntryPoint < Base
+        include DefNode
+
+        ALLOWED_PUBLIC_METHODS = %i[call initialize].freeze
+        MSG = 'Service objects should only have one entry point: `ServiceClass.call()`.'
+
+        def on_def(node)
+          return if non_public?(node)
+          return if ALLOWED_PUBLIC_METHODS.include? node.method_name
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/florence_cops.rb
+++ b/lib/rubocop/cop/florence_cops.rb
@@ -1,1 +1,2 @@
 # frozen_string_literal: true
+require_relative 'florence/service_single_entry_point'

--- a/lib/rubocop/cop/florence_cops.rb
+++ b/lib/rubocop/cop/florence_cops.rb
@@ -1,2 +1,3 @@
 # frozen_string_literal: true
+
 require_relative 'florence/service_single_entry_point'

--- a/spec/rubocop/cop/florence/service_single_entry_point_spec.rb
+++ b/spec/rubocop/cop/florence/service_single_entry_point_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Florence::ServiceSingleEntryPoint, :config do
+  let(:config) { RuboCop::Config.new }
+
+  it 'registers no offence when the only public methods are .call, #initialize, and #call' do
+    expect_no_offenses(<<~RUBY)
+      class ServiceClass
+        def self.call; end
+
+        def initialize; end
+
+        def call; end
+
+        protected
+
+        def protected_method; end
+
+        private
+
+        def private_method; end
+      end
+    RUBY
+  end
+
+  it 'registers an offence when there is an extra public method' do
+    expect_offense(<<~RUBY)
+      class ServiceClass
+        def self.call; end
+
+        def initialize; end
+
+        def call; end
+
+        def extra_public_method; end
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Service objects should only have one entry point: `ServiceClass.call()`.
+        protected
+
+        def protected_method; end
+
+        private
+
+        def private_method; end
+      end
+    RUBY
+  end
+end


### PR DESCRIPTION
This PR introduces the Florence/ServiceSingleEntryPoint cop to ensure that our service objects have a single entry point and therefore help enforce single responsibility