### PR TITLE
Add cop UUID primary key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,4 +14,5 @@ RSpec:
       - expect_no_offenses
       - expect_offense
 RSpec/ExampleLength:
-  Max: 13
+  CountAsOne:
+    - heredoc

--- a/config/default.yml
+++ b/config/default.yml
@@ -6,6 +6,10 @@ inherit_mode:
 AllCops:
   NewCops: enable
 
+Florence/UuidPrimaryKey:
+  Description: 'Database tables should use uuid primary keys.'
+  Enabled: false
+  VersionAdded: '0.12.0'
 Florence/ServiceSingleEntryPoint:
   Description: 'Service objects should only have one entry point.'
   Enabled: false

--- a/lib/rubocop/cop/florence/uuid_primary_key.rb
+++ b/lib/rubocop/cop/florence/uuid_primary_key.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Florence
+      class UuidPrimaryKey < Base
+        RESTRICT_ON_SEND = [:create_table].freeze
+        MSG = 'Use uuid primary keys.'
+
+        def on_send(node)
+          id_argument = find_id_argument(node)
+
+          return if id_argument&.sym_type? && id_argument.value == :uuid
+
+          add_offense(node)
+        end
+
+        private
+
+        def find_id_argument(send_node)
+          return unless send_node.last_argument&.hash_type?
+
+          send_node.last_argument.each_pair.find do |pair|
+            next unless pair.key.sym_type? && pair.key.value == :id
+
+            break pair.value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/florence/uuid_primary_key.rb
+++ b/lib/rubocop/cop/florence/uuid_primary_key.rb
@@ -4,6 +4,8 @@ module RuboCop
   module Cop
     module Florence
       class UuidPrimaryKey < Base
+        extend AutoCorrector
+
         RESTRICT_ON_SEND = [:create_table].freeze
         MSG = 'Use uuid primary keys.'
 
@@ -12,7 +14,13 @@ module RuboCop
 
           return if id_argument&.sym_type? && id_argument.value == :uuid
 
-          add_offense(node)
+          add_offense(node) do |corrector|
+            if id_argument.nil?
+              corrector.insert_after(node, ', id: :uuid')
+            else
+              corrector.replace(id_argument, ':uuid')
+            end
+          end
         end
 
         private

--- a/lib/rubocop/cop/florence/uuid_primary_key.rb
+++ b/lib/rubocop/cop/florence/uuid_primary_key.rb
@@ -19,13 +19,7 @@ module RuboCop
 
           return if id_argument&.sym_type? && id_argument.value == :uuid
 
-          add_offense(node) do |corrector|
-            if id_argument.nil?
-              corrector.insert_after(node, ', id: :uuid')
-            else
-              corrector.replace(id_argument, ':uuid')
-            end
-          end
+          add_offense(node) { |corrector| add_uuid_option(corrector, node, id_argument) }
         end
 
         private
@@ -37,6 +31,16 @@ module RuboCop
             next unless pair.key.sym_type? && pair.key.value == :id
 
             break pair.value
+          end
+        end
+
+        def add_uuid_option(corrector, node, id_argument)
+          if node.last_argument.nil?
+            corrector.insert_after(node, ' id: :uuid')
+          elsif id_argument.nil?
+            corrector.insert_after(node, ', id: :uuid')
+          else
+            corrector.replace(id_argument, ':uuid')
           end
         end
       end

--- a/lib/rubocop/cop/florence/uuid_primary_key.rb
+++ b/lib/rubocop/cop/florence/uuid_primary_key.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 
+require 'rubocop-rails'
+
 module RuboCop
   module Cop
     module Florence
       class UuidPrimaryKey < Base
+        include MigrationsHelper
         extend AutoCorrector
 
         RESTRICT_ON_SEND = [:create_table].freeze
         MSG = 'Use uuid primary keys.'
 
         def on_send(node)
+          return unless in_migration?(node)
+
           id_argument = find_id_argument(node)
 
           return if id_argument&.sym_type? && id_argument.value == :uuid

--- a/lib/rubocop/cop/florence_cops.rb
+++ b/lib/rubocop/cop/florence_cops.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
 require_relative 'florence/service_single_entry_point'
+require_relative 'florence/uuid_primary_key'

--- a/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
+++ b/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
@@ -1,69 +1,119 @@
 # frozen_string_literal: true
 
 RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
-  it 'registers no offence when create_table specifies a uuid primary key' do
-    expect_no_offenses(<<~RUBY)
-      create_table :table_name, id: :uuid
-    RUBY
+  context 'when not within a migration class' do
+    it 'registers no offence when create_table is not within a migration' do
+      expect_no_offenses(<<~RUBY)
+        create_table :table_name, id: :not_uuid
+      RUBY
+    end
   end
 
-  it 'registers no offence when create_table specifies a uuid primary key, other options, and a block' do
-    expect_no_offenses(<<~RUBY)
-      create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
-        t.string :column_name
-      end
-    RUBY
-  end
+  context 'when within a migration' do
+    it 'registers no offence when create_table specifies a uuid primary key' do
+      expect_no_offenses(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, id: :uuid
+          end
+        end
+      RUBY
+    end
 
-  it 'registers an offence when create_table does not specify primary key' do
-    expect_offense(<<~RUBY)
-      create_table :table_name
-      ^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
-    RUBY
+    it 'registers no offence when create_table specifies a uuid primary key, other options, and a block' do
+      expect_no_offenses(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+    end
 
-    expect_correction(<<~RUBY)
-      create_table :table_name, id: :uuid
-    RUBY
-  end
+    it 'registers an offence when create_table does not specify primary key' do
+      expect_offense(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name
+            ^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+          end
+        end
+      RUBY
 
-  it 'registers an offence when create_table specifies a primary key other than uuid' do
-    expect_offense(<<~RUBY)
-      create_table :table_name, id: :not_uuid
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
-    RUBY
+      expect_correction(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, id: :uuid
+          end
+        end
+      RUBY
+    end
 
-    expect_correction(<<~RUBY)
-      create_table :table_name, id: :uuid
-    RUBY
-  end
+    it 'registers an offence when create_table specifies a primary key other than uuid' do
+      expect_offense(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, id: :not_uuid
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+          end
+        end
+      RUBY
 
-  it 'registers an offence when create_table specifies options and a block but does not specify primary key' do
-    expect_offense(<<~RUBY)
-      create_table :table_name, foo: :bar do |t|
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
-        t.string :column_name
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, id: :uuid
+          end
+        end
+      RUBY
+    end
 
-    expect_correction(<<~RUBY)
-      create_table :table_name, foo: :bar, id: :uuid do |t|
-        t.string :column_name
-      end
-    RUBY
-  end
+    it 'registers an offence when create_table specifies options and a block but does not specify primary key' do
+      expect_offense(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, foo: :bar do |t|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
 
-  it 'registers an offence when create_table a primary key other than uuid, other options, and a block' do
-    expect_offense(<<~RUBY)
-      create_table :table_name, foo: :bar, id: :not_uuid, baz: :qux do |t|
-      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
-        t.string :column_name
-      end
-    RUBY
+      expect_correction(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, foo: :bar, id: :uuid do |t|
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+    end
 
-    expect_correction(<<~RUBY)
-      create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
-        t.string :column_name
-      end
-    RUBY
+    it 'registers an offence when create_table a primary key other than uuid, other options, and a block' do
+      expect_offense(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, foo: :bar, id: :not_uuid, baz: :qux do |t|
+            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+    end
   end
 end

--- a/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
+++ b/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
@@ -20,12 +20,20 @@ RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
       create_table :table_name
       ^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
     RUBY
+
+    expect_correction(<<~RUBY)
+      create_table :table_name, id: :uuid
+    RUBY
   end
 
   it 'registers an offence when create_table specifies a primary key other than uuid' do
     expect_offense(<<~RUBY)
       create_table :table_name, id: :not_uuid
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+    RUBY
+
+    expect_correction(<<~RUBY)
+      create_table :table_name, id: :uuid
     RUBY
   end
 
@@ -36,12 +44,24 @@ RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
         t.string :column_name
       end
     RUBY
+
+    expect_correction(<<~RUBY)
+      create_table :table_name, foo: :bar, id: :uuid do |t|
+        t.string :column_name
+      end
+    RUBY
   end
 
   it 'registers an offence when create_table a primary key other than uuid, other options, and a block' do
     expect_offense(<<~RUBY)
       create_table :table_name, foo: :bar, id: :not_uuid, baz: :qux do |t|
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+        t.string :column_name
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
         t.string :column_name
       end
     RUBY

--- a/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
+++ b/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
+  it 'registers no offence when create_table specifies a uuid primary key' do
+    expect_no_offenses(<<~RUBY)
+      create_table :table_name, id: :uuid
+    RUBY
+  end
+
+  it 'registers no offence when create_table specifies a uuid primary key, other options, and a block' do
+    expect_no_offenses(<<~RUBY)
+      create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
+        t.string :column_name
+      end
+    RUBY
+  end
+
+  it 'registers an offence when create_table does not specify primary key' do
+    expect_offense(<<~RUBY)
+      create_table :table_name
+      ^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+    RUBY
+  end
+
+  it 'registers an offence when create_table specifies a primary key other than uuid' do
+    expect_offense(<<~RUBY)
+      create_table :table_name, id: :not_uuid
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+    RUBY
+  end
+
+  it 'registers an offence when create_table specifies options and a block but does not specify primary key' do
+    expect_offense(<<~RUBY)
+      create_table :table_name, foo: :bar do |t|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+        t.string :column_name
+      end
+    RUBY
+  end
+
+  it 'registers an offence when create_table a primary key other than uuid, other options, and a block' do
+    expect_offense(<<~RUBY)
+      create_table :table_name, foo: :bar, id: :not_uuid, baz: :qux do |t|
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Use uuid primary keys.
+        t.string :column_name
+      end
+    RUBY
+  end
+end

--- a/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
+++ b/spec/rubocop/cop/florence/uuid_primary_key_spec.rb
@@ -93,7 +93,7 @@ RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
       RUBY
     end
 
-    it 'registers an offence when create_table a primary key other than uuid, other options, and a block' do
+    it 'registers an offence when create_table specifies a primary key other than uuid, other options, and a block' do
       expect_offense(<<~RUBY)
         class MigrationName < ActiveRecord::Migration[7.1]
           def change
@@ -109,6 +109,29 @@ RSpec.describe RuboCop::Cop::Florence::UuidPrimaryKey, :config do
         class MigrationName < ActiveRecord::Migration[7.1]
           def change
             create_table :table_name, foo: :bar, id: :uuid, baz: :qux do |t|
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+    end
+
+    it 'registers an offence when create_table has no arguments' do
+      expect_offense(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table do |t|
+            ^^^^^^^^^^^^ Use uuid primary keys.
+              t.string :column_name
+            end
+          end
+        end
+      RUBY
+
+      expect_correction(<<~RUBY)
+        class MigrationName < ActiveRecord::Migration[7.1]
+          def change
+            create_table id: :uuid do |t|
               t.string :column_name
             end
           end


### PR DESCRIPTION
Specifically for use in florence-auth, this cop will flag an offence for any migration which creates a new database table without specifying a uuid primary key