### PR TITLE
Set Metrics/ParameterLists to exclude keyword args

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -7,14 +7,14 @@ AllCops:
   NewCops: enable
 
 Florence/UuidPrimaryKey:
-  Description: 'Database tables should use uuid primary keys.'
+  Description: "Database tables should use uuid primary keys."
   Enabled: false
-  VersionAdded: '0.12.0'
+  VersionAdded: "0.12.0"
 Florence/ServiceSingleEntryPoint:
-  Description: 'Service objects should only have one entry point.'
+  Description: "Service objects should only have one entry point."
   Enabled: false
-  VersionAdded: '0.3.0'
-  Include: ['app/**/services/**/*.rb']
+  VersionAdded: "0.3.0"
+  Include: ["app/**/services/**/*.rb"]
 
 Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
@@ -40,6 +40,9 @@ Lint/MissingSuper:
 
 Metrics/BlockLength:
   Exclude: [./config/routes.rb]
+
+Metrics/ParameterLists:
+  CountKeywordArgs: false
 
 Rails/UnknownEnv:
   Environments: [staging]


### PR DESCRIPTION
The cop has this option on the rationale that keyword arguments add much less complexity than positional ones.

There are a couple of cases that I know about where initialisers with lots of keyword arguments had to be rewritten, to the detriment of the code.