### PR TITLE
Upgrade CI to use latest ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.0.6
+          ruby-version: 3.3.4
       - run: bundle exec rspec
   lint:
     runs-on: ubuntu-latest
@@ -18,5 +18,5 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 3.0.6
+          ruby-version: 3.3.4
       - run: bundle exec rubocop


### PR DESCRIPTION
We're now using this across all our ruby apps, so let's use it here too.