### PR TITLE
Add rubocop-rspec_rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       rubocop-rails (= 2.24.1)
       rubocop-rake (= 0.6.0)
       rubocop-rspec (= 3.1.0)
+      rubocop-rspec_rails (= 2.30.0)
       rubocop-thread_safety (= 0.5.1)
 
 GEM
@@ -89,6 +90,9 @@ GEM
       rubocop (~> 1.0)
     rubocop-rspec (3.1.0)
       rubocop (~> 1.61)
+    rubocop-rspec_rails (2.30.0)
+      rubocop (~> 1.61)
+      rubocop-rspec (~> 3, >= 3.0.1)
     rubocop-thread_safety (0.5.1)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.13.0)

--- a/rubocop-florence.gemspec
+++ b/rubocop-florence.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-rails', '2.24.1'
   spec.add_runtime_dependency 'rubocop-rake', '0.6.0'
   spec.add_runtime_dependency 'rubocop-rspec', '3.1.0'
+  spec.add_runtime_dependency 'rubocop-rspec_rails', '2.30.0'
   spec.add_runtime_dependency 'rubocop-thread_safety', '0.5.1'
   spec.metadata['rubygems_mfa_required'] = 'true'
 end


### PR DESCRIPTION
This is recommended by the latest rubocop version - it prints a message every time to make sure you know.

It requires no changes in flex, so I'm adding it.