### PR TITLE
Disable Rails/WhereRange

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -46,6 +46,8 @@ Metrics/ParameterLists:
 
 Rails/UnknownEnv:
   Environments: [staging]
+Rails/WhereRange:
+  Enabled: false
 
 RSpec/ExpectInHook:
   Enabled: false


### PR DESCRIPTION
This caused a lot of changes which can be autocorrected, but not safely, making it more effort and risk to change. I got quite a few spec failures.

It also changes SQL conditions from `>= ?` `<= ?` to `..` and `>` `<` to `...`. I really don't think this is an improvement, and it is harder to spot (and understand) the difference between `..` and `...`.